### PR TITLE
Add Vercel domain to CORS configuration

### DIFF
--- a/backend/src/main/java/com/back/teamcoffee/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/teamcoffee/global/security/SecurityConfig.java
@@ -48,7 +48,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
+        configuration.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "https://nbe-6-8-1-team01.vercel.app"
+        ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## Summary
Vercel 배포된 프론트엔드가 백엔드 API와 통신할 수 있도록 CORS 설정에 Vercel 도메인을 추가합니다.

## Changes
**SecurityConfig.java**
```java
configuration.setAllowedOrigins(List.of(
    "http://localhost:3000",
    "https://nbe-6-8-1-team01.vercel.app"  // 추가
));
```

## Details
- **Vercel URL**: https://nbe-6-8-1-team01.vercel.app
- **Protocol**: HTTPS (Vercel은 기본적으로 HTTPS 사용)
- **Credentials**: true 유지 (쿠키 기반 인증을 위해 필요)

## Test
- 로컬 개발 환경 (http://localhost:3000) 계속 작동 ✅
- Vercel 프로덕션 환경에서 API 호출 가능 (백엔드 배포 후 확인 필요)

## Next Steps
1. 이 PR 병합
2. 백엔드 재배포
3. https://nbe-6-8-1-team01.vercel.app 에서 API 연동 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)