### PR TITLE
Fix CORS OPTIONS request 401 error

### DIFF
--- a/backend/src/main/java/com/back/teamcoffee/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/back/teamcoffee/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.back.teamcoffee.domain.user.entity.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -30,6 +31,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
 
                 .authorizeHttpRequests(reg -> reg
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // CORS preflight 요청 허용
                         .requestMatchers("/users/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()


### PR DESCRIPTION
## Summary
CORS preflight(OPTIONS) 요청이 401 Unauthorized로 차단되는 문제를 해결합니다.

## Problem
- Vercel 앱에서 API 호출 시 OPTIONS 요청이 401 에러 발생
- Spring Security가 OPTIONS 요청을 인증이 필요한 요청으로 처리

## Solution
```java
.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()  // 추가
```
모든 경로에 대한 OPTIONS 요청을 명시적으로 허용

## Test
1. 이 PR 병합
2. 백엔드 서버 재시작
3. https://nbe-6-8-1-team01.vercel.app/signup 에서 회원가입 테스트

## Expected Result
- OPTIONS 요청: 200 OK (401 대신)
- POST /users 요청 정상 진행

🤖 Generated with [Claude Code](https://claude.ai/code)