### PR TITLE
Add WebConfig for proper CORS handling

### DIFF
--- a/backend/src/main/java/com/back/teamcoffee/global/config/WebConfig.java
+++ b/backend/src/main/java/com/back/teamcoffee/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.back.teamcoffee.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "https://nbe-6-8-1-team01.vercel.app"
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
## Summary
OPTIONS 요청이 403 Forbidden을 반환하고 CORS 헤더가 없는 문제를 해결합니다.

## Problem
- SecurityConfig의 CORS 설정만으로는 헤더가 제대로 추가되지 않음
- OPTIONS 요청에 대한 응답에 Access-Control-Allow-* 헤더가 없음

## Solution
`WebConfig` 클래스 추가:
```java
@Configuration
public class WebConfig implements WebMvcConfigurer {
    @Override
    public void addCorsMappings(CorsRegistry registry) {
        registry.addMapping("/**")
                .allowedOrigins(
                    "http://localhost:3000",
                    "https://nbe-6-8-1-team01.vercel.app"
                )
                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                .allowedHeaders("*")
                .allowCredentials(true)
                .maxAge(3600);
    }
}
```

## Why this works
- Spring MVC의 CORS 처리가 Spring Security보다 먼저 실행됨
- WebMvcConfigurer를 통한 CORS 설정이 더 확실하게 작동

## Test
1. 이 PR 병합
2. 서버 재시작
3. OPTIONS 요청 시 200 OK와 함께 CORS 헤더 확인

🤖 Generated with [Claude Code](https://claude.ai/code)