### PR TITLE
fix: 로그인 DTO에서 불필요한 username, role 필드 제거

### DIFF
--- a/backend/src/main/java/com/back/teamcoffee/domain/user/dto/UserLoginRequestDto.java
+++ b/backend/src/main/java/com/back/teamcoffee/domain/user/dto/UserLoginRequestDto.java
@@ -1,13 +1,10 @@
 package com.back.teamcoffee.domain.user.dto;
 
-import com.back.teamcoffee.domain.user.entity.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record UserLoginRequestDto(
-        @NotBlank(message = "사용자 이름은 필수입니다") String username,
         @NotBlank(message = "이메일은 필수입니다") @Email String email,
-        @NotBlank(message = "비밀번호는 필수입니다.")@Size(min = 4, message = "비밀번호는 4자 이상이어야 합니다.") String password,
-        UserRole role
+        @NotBlank(message = "비밀번호는 필수입니다.")@Size(min = 4, message = "비밀번호는 4자 이상이어야 합니다.") String password
 ) {}


### PR DESCRIPTION
## Summary
- 로그인 시 username 필드를 요구하는 문제 수정
- UserLoginRequestDto에서 불필요한 username과 role 필드 제거
- 로그인에는 이메일과 비밀번호만 필요

## Changes
- `UserLoginRequestDto.java`: username, role 필드 및 관련 import 제거

## Test plan
- [ ] 로그인 API 테스트 (이메일, 비밀번호만으로 로그인 가능)
- [ ] 프론트엔드에서 로그인 폼 정상 작동 확인

🤖 Generated with [Claude Code](https://claude.ai/code)