### PR TITLE
fix: Vercel 빌드 오류 수정 - productsApi 및 deleteUser 타입 오류

### DIFF
--- a/frontend/app/account/page.tsx
+++ b/frontend/app/account/page.tsx
@@ -42,7 +42,7 @@ export default function AccountPage() {
       setIsDeleting(true)
       const response = await authApi.deleteUser(user.email)
       
-      if (response.success) {
+      if (response.resultCode === '200-DELETED') {
         toast({
           title: "회원 탈퇴 완료",
           description: "그동안 이용해주셔서 감사합니다.",

--- a/frontend/app/admin/products/page.tsx
+++ b/frontend/app/admin/products/page.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { useAuth } from "@/contexts/AuthContext"
-import { productsApi } from "@/lib/api"
+import { productApi } from "@/lib/api"
 import { useRouter } from "next/navigation"
 import { useToast } from "@/hooks/use-toast"
 import { Trash2, Edit, Plus, Package, Loader2 } from "lucide-react"
@@ -66,7 +66,7 @@ export default function AdminProductsPage() {
   const fetchProducts = async () => {
     try {
       setIsLoading(true)
-      const response = await productsApi.getProducts()
+      const response = await productApi.getProducts()
       if (response.success) {
         setProducts(response.data)
       }
@@ -104,7 +104,7 @@ export default function AdminProductsPage() {
 
       if (editingProduct) {
         // 수정 API 호출
-        const response = await productsApi.updateProduct(editingProduct.productId, productData)
+        const response = await productApi.updateProduct(editingProduct.productId, productData)
         if (response.success) {
           toast({
             title: "상품 수정 완료",
@@ -113,7 +113,7 @@ export default function AdminProductsPage() {
         }
       } else {
         // 등록 API 호출
-        const response = await productsApi.createProduct(productData)
+        const response = await productApi.createProduct(productData)
         if (response.success) {
           toast({
             title: "상품 등록 완료",
@@ -141,7 +141,7 @@ export default function AdminProductsPage() {
     if (!confirm('정말로 이 상품을 삭제하시겠습니까?')) return
 
     try {
-      const response = await productsApi.deleteProduct(productId)
+      const response = await productApi.deleteProduct(productId)
       if (response.success) {
         toast({
           title: "상품 삭제 완료",


### PR DESCRIPTION
## Summary
Vercel 빌드 시 발생하는 오류를 수정합니다.

## 수정 내용
1. **productsApi import 오류 수정**
   - `productsApi` → `productApi`로 모든 import 변경
   - admin/products/page.tsx 파일의 5개 위치 수정

2. **deleteUser API 응답 타입 오류 수정**
   - `response.success` → `response.resultCode === '200-DELETED'`로 변경
   - account/page.tsx 파일 수정

## 오류 내용
```
Attempted import error: 'productsApi' is not exported from '@/lib/api'
Type error: Property 'success' does not exist on type 'ApiResponse<void>'
```

🤖 Generated with [Claude Code](https://claude.ai/code)