### PR TITLE
fix: user.name을 user.username으로 수정

### DIFF
--- a/frontend/app/account/page.tsx
+++ b/frontend/app/account/page.tsx
@@ -111,7 +111,7 @@ export default function AccountPage() {
                   <User className="w-5 h-5 text-mediterranean-terracotta" />
                   <div>
                     <p className="text-sm text-gray-600">이름</p>
-                    <p className="font-semibold">{user?.name}</p>
+                    <p className="font-semibold">{user?.username}</p>
                   </div>
                 </div>
                 


### PR DESCRIPTION
## Summary
account 페이지에서 발생하는 타입 오류를 수정합니다.

## 수정 내용
- `user?.name` → `user?.username`으로 변경
- AuthContext의 user 타입에 맞게 수정

## 오류 내용
```
Type error: Property 'name' does not exist on type '{ username: string; email: string; address: string; role: string; }'.
```

🤖 Generated with [Claude Code](https://claude.ai/code)