### PR TITLE
fix: lucide-react 아이콘 import 누락 수정

### DIFF
--- a/frontend/app/account/page.tsx
+++ b/frontend/app/account/page.tsx
@@ -8,7 +8,7 @@ import { useAuth } from "@/contexts/AuthContext"
 import { authApi } from "@/lib/api"
 import { useRouter } from "next/navigation"
 import { useToast } from "@/hooks/use-toast"
-import { User, Mail, Calendar, Shield, AlertTriangle, Loader2 } from "lucide-react"
+import { User, Mail, Calendar, Shield, AlertTriangle, Loader2, Package, Heart } from "lucide-react"
 import { motion } from "framer-motion"
 import {
   AlertDialog,


### PR DESCRIPTION
## Summary
account 페이지에서 누락된 아이콘 import를 추가합니다.

## 수정 내용
- `Package`, `Heart` 아이콘 import 추가

## 오류 내용
```
Type error: Cannot find name 'Package'.
Type error: Cannot find name 'Heart'.
```

🤖 Generated with [Claude Code](https://claude.ai/code)