### PR TITLE
fix: 모든 API 응답 체크를 resultCode로 통일

### DIFF
--- a/frontend/app/admin/orders/page.tsx
+++ b/frontend/app/admin/orders/page.tsx
@@ -110,7 +110,7 @@ export default function AdminOrdersPage() {
       // 실제로는 관리자용 전체 주문 API가 필요합니다
       // 지금은 임시로 사용자별 조회를 사용합니다
       const response = await orderApi.getOrdersByEmail('admin@email.com')
-      if (response.success) {
+      if (response.resultCode === '200-OK') {
         setAllOrders(response.data)
       }
     } catch (error) {
@@ -122,7 +122,7 @@ export default function AdminOrdersPage() {
   const fetchTodayOrders = async () => {
     try {
       const response = await orderApi.getTodayOrders()
-      if (response.success) {
+      if (response.resultCode === '200-OK') {
         setTodayOrders(response.data)
       }
     } catch (error) {
@@ -148,7 +148,7 @@ export default function AdminOrdersPage() {
       setUpdatingOrder(orderId)
       const response = await orderApi.updateOrderStatus(orderId, newStatus)
       
-      if (response.success) {
+      if (response.resultCode === '200-OK') {
         toast({
           title: "상태 변경 완료",
           description: "주문 상태가 변경되었습니다."

--- a/frontend/app/admin/products/page.tsx
+++ b/frontend/app/admin/products/page.tsx
@@ -67,7 +67,7 @@ export default function AdminProductsPage() {
     try {
       setIsLoading(true)
       const response = await productApi.getProducts()
-      if (response.success) {
+      if (response.resultCode === '200-OK') {
         setProducts(response.data)
       }
     } catch (error) {
@@ -105,7 +105,7 @@ export default function AdminProductsPage() {
       if (editingProduct) {
         // 수정 API 호출
         const response = await productApi.updateProduct(editingProduct.productId, productData)
-        if (response.success) {
+        if (response.resultCode === '200-OK') {
           toast({
             title: "상품 수정 완료",
             description: "상품이 성공적으로 수정되었습니다."
@@ -114,7 +114,7 @@ export default function AdminProductsPage() {
       } else {
         // 등록 API 호출
         const response = await productApi.createProduct(productData)
-        if (response.success) {
+        if (response.resultCode === '200-OK') {
           toast({
             title: "상품 등록 완료",
             description: "새 상품이 성공적으로 등록되었습니다."
@@ -142,7 +142,7 @@ export default function AdminProductsPage() {
 
     try {
       const response = await productApi.deleteProduct(productId)
-      if (response.success) {
+      if (response.resultCode === '200-DELETED') {
         toast({
           title: "상품 삭제 완료",
           description: "상품이 성공적으로 삭제되었습니다."

--- a/frontend/app/orders/page.tsx
+++ b/frontend/app/orders/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react"
 import { Navigation } from "@/components/Navigation"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { Package, Clock, CheckCircle, Truck, Coffee, CalendarDays, ChevronRight, Loader2 } from "lucide-react"
+import { Package, Clock, CheckCircle, Truck, Coffee, CalendarDays, ChevronRight, Loader2, X } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
 import Link from "next/link"
 import Image from "next/image"
@@ -116,7 +116,7 @@ export default function OrdersPage() {
       setCancellingOrder(orderId)
       const response = await orderApi.cancelOrder(orderId)
       
-      if (response.success) {
+      if (response.resultCode === '200-OK') {
         toast({
           title: "주문 취소 완료",
           description: "주문이 성공적으로 취소되었습니다.",
@@ -124,7 +124,7 @@ export default function OrdersPage() {
         
         // 주문 목록 새로고침
         const refreshResponse = await orderApi.getMyOrders(user?.email || '')
-        if (refreshResponse.success) {
+        if (refreshResponse.resultCode === 'SUCCESS') {
           setOrders(refreshResponse.data)
         }
       }

--- a/frontend/app/products/[id]/page.tsx
+++ b/frontend/app/products/[id]/page.tsx
@@ -113,7 +113,7 @@ export default function ProductDetailPage() {
       
       const response = await orderApi.createOrder(orderData)
       
-      if (response.success) {
+      if (response.resultCode === '200-OK') {
         toast({
           title: "주문 완료",
           description: "주문이 성공적으로 접수되었습니다.",

--- a/frontend/app/wishlist/page.tsx
+++ b/frontend/app/wishlist/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { Navigation } from "@/components/Navigation"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -250,7 +250,7 @@ export default function WishlistPage() {
                           
                           const response = await orderApi.createOrder(orderData)
                           
-                          if (response.success) {
+                          if (response.resultCode === '200-OK') {
                             toast({
                               title: "주문 완료",
                               description: "위시리스트 상품들의 주문이 접수되었습니다.",


### PR DESCRIPTION
## Summary
프론트엔드 전체에서 API 응답 체크를 백엔드 실제 응답 형식에 맞게 수정합니다.

## 수정 내용
### 1. API 응답 체크 방식 변경
- `response.success` → `response.resultCode === '200-OK'` (일반 성공)
- `response.success` → `response.resultCode === '200-DELETED'` (삭제 성공)

### 2. 수정된 파일
- **admin/products/page.tsx**: 상품 CRUD 응답 체크 (4곳)
- **admin/orders/page.tsx**: 주문 관리 응답 체크 (3곳)
- **wishlist/page.tsx**: 주문 생성 응답 체크 (1곳)
- **orders/page.tsx**: 주문 취소 응답 체크 (1곳)
- **products/[id]/page.tsx**: 주문 생성 응답 체크 (1곳)

### 3. 추가 수정
- wishlist/page.tsx: useState import 추가
- orders/page.tsx: X 아이콘 import 추가

## 오류 내용
```
Type error: Property 'success' does not exist on type 'ApiResponse<T>'.
```

🤖 Generated with [Claude Code](https://claude.ai/code)